### PR TITLE
Hot fix responsiv and todos order

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,12 +20,14 @@ import { ToDoEffects } from './redux/todo.effects';
 
 import { routerReducer } from '@ngrx/router-store';
 import { TodoComponent } from './todos/todo/todo.component';
+import { ReversePipe } from './pipes/reverse.pipe';
 @NgModule({
   declarations: [
     AppComponent,
     MenuComponent,
     TodosComponent,
-    TodoComponent
+    TodoComponent,
+    ReversePipe
   ],
   imports: [
     BrowserModule,

--- a/src/app/pipes/reverse.pipe.spec.ts
+++ b/src/app/pipes/reverse.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { ReversePipe } from './reverse.pipe';
+
+describe('ReversePipe', () => {
+  it('create an instance', () => {
+    const pipe = new ReversePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/pipes/reverse.pipe.ts
+++ b/src/app/pipes/reverse.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'reverse'
+})
+export class ReversePipe implements PipeTransform {
+
+  transform(value: any, args?: any): any {
+    return null;
+  }
+
+}

--- a/src/app/pipes/reverse.pipe.ts
+++ b/src/app/pipes/reverse.pipe.ts
@@ -1,12 +1,15 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { TodoModel } from '../models/todo.model';
 
 @Pipe({
   name: 'reverse'
 })
 export class ReversePipe implements PipeTransform {
 
-  transform(value: any, args?: any): any {
-    return null;
+  transform(value: Array<TodoModel>, args?: any): any {
+    return value.sort( (a, b) => {
+      return b.id - a.id;
+    });
   }
 
 }

--- a/src/app/todos/todo/todo.component.sass
+++ b/src/app/todos/todo/todo.component.sass
@@ -1,7 +1,13 @@
 .container
+  display: flex
+  flex-direction: column
   margin: auto
+  margin-bottom: 30px
   width: 25%
+  align-items: center
 
 .todo
+  min-width: 200px
   max-width: 400px
   margin: 10px
+  width: 100%

--- a/src/app/todos/todos.component.html
+++ b/src/app/todos/todos.component.html
@@ -33,7 +33,12 @@
     <mat-card-header>
       <mat-card-title style="cursor: pointer;">
         <mat-checkbox [checked]="todo.isDone" (change)="changeTodo(todo.id)" labelPosition='after'></mat-checkbox>
-        <span [routerLink]="['/todo', todo.id]">&nbsp;{{todo.title }}&nbsp;</span>
+        <span [routerLink]="['/todo', todo.id]">
+          &nbsp;{{todo.title }}&nbsp;
+          <mat-icon *ngIf="todo.description" aria-hidden="false" aria-label="Todo description" class="description">
+            more_horiz
+          </mat-icon>
+        </span>
       </mat-card-title>
     </mat-card-header>
   </mat-card>

--- a/src/app/todos/todos.component.html
+++ b/src/app/todos/todos.component.html
@@ -29,7 +29,7 @@
 <!-- </div>
 
 <div class="container"> -->
-  <mat-card class="todo" *ngFor="let todo of todos.reverse(); index as i" [ngClass]="{'done': todo.isDone, 'bottom': todo.isDone}">
+  <mat-card class="todo" *ngFor="let todo of todos | reverse ; index as i" [ngClass]="{'done': todo.isDone, 'bottom': todo.isDone}">
     <mat-card-header>
       <mat-card-title style="cursor: pointer;">
         <mat-checkbox [checked]="todo.isDone" (change)="changeTodo(todo.id)" labelPosition='after'></mat-checkbox>

--- a/src/app/todos/todos.component.sass
+++ b/src/app/todos/todos.component.sass
@@ -18,3 +18,6 @@
 
 .bottom
   order: 1
+
+.description
+  opacity: 0.5


### PR DESCRIPTION
This PR aim at resolving the following issues : 

- Bug : Not mobile responsiv when displaying a single todo page
- Nice to have : a visual indicator on the todos list, that say whether a description exist or not.
- Bug : todos are not necessarly displayed in the correct order. NgFor on todos.reverse() is clearly not working. A custom pipe sorting the todos array is used instead.